### PR TITLE
Support shapes with more than 10 sides in example

### DIFF
--- a/examples/shape/procedural-shapes/for-sincos2.js
+++ b/examples/shape/procedural-shapes/for-sincos2.js
@@ -9,7 +9,7 @@ function setup()
   const spacing = 360 / numVertices;
   translate(width/2, height/2);
   beginShape();
-  for(let i = 0; i < 10; i++) {
+  for(let i = 0; i <= numVertices; i++) {
     const x = cos(radians(i * spacing)) * 100;
     const y = sin(radians(i * spacing)) * 100;
     vertex(x, y);


### PR DESCRIPTION
The previous version of the for loop would stop after 10 iterations, resulting in a shape that was partially rendered if it had more than 10 sides. This change should now do what it says on the tin, creating shapes with "4 or 30" vertices.