### PR TITLE
Increase code snippet lines for flower example

### DIFF
--- a/content/shape/procedural-shapes.html
+++ b/content/shape/procedural-shapes.html
@@ -145,7 +145,7 @@ const y = sin(RADIANS) * RADIUS;</code></pre>
     <p>Here is a flower created with <code>quadraticVertex()</code> where all vertices and control points are positioned using <code>sin()</code> and <code>cos()</code>. By using a larger radius for the control points (the inverse of the star example above), the curves go outwards. When using Bézier curves, remember to start the shape with a <code>vertex()</code> function call. We do this by checking the value of <code>i</code> within the loop.</p>
 
     {% p5 shape/procedural-shapes/flower.js class:'text-width' %}
-    {% codesplit shape/procedural-shapes/flower.js lines:'10-36' class:'columns' %}
+    {% codesplit shape/procedural-shapes/flower.js lines:'8-36' class:'columns' %}
 
     <p>You will often find yourself needing to use just one of the circular functions. The two shapes below are created just like that: The first one uses <code>sin()</code> and the second one uses <code>cos()</code> (as demonstrated in the code below).</p>
 


### PR DESCRIPTION
Increasing starting line number for flower code split from 10 to 8 to include `translate(width/2, height/2);` so that when user copies and pastes code, flower renders in the center instead of top left corner.